### PR TITLE
Add ipa-extra-hardware element

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,3 +24,5 @@ This repository provides the following DIB elements:
 * ``sriov-hypervisor``: Prepare a hypervisor with networking preparation for SR-IOV support.
 * ``hpc-hypervisor``: Kernel and package optimisations for hypervisor virt optimisations.
 * ``dhcp-on``: Configures network for DHCP only on a single, configurable interface name.
+* ``ipa-extra-hardware``: Installs tools for enhanced hardware inspection in an
+  Ironic Python Agent (IPA) ramdisk image.

--- a/elements/ipa-extra-hardware/README.rst
+++ b/elements/ipa-extra-hardware/README.rst
@@ -1,0 +1,20 @@
+========================================
+Ironic Python Agent (IPA) Extra Hardware
+========================================
+
+This element has been designed to work with the ``ironic-agent`` element, and
+adds the `hardware <https://pypi.python.org/pypi/hardware>`_ python
+package to the Ironic Python Agent (IPA) ramdisk. It also installs several
+package dependencies of the ``hardware`` module.
+
+The ``hardware`` package provides improved hardware introspection capabilities
+and supports benchmarking. This functionality may be enabled by adding the
+``extra-hardware`` collector in the ``[DEFAULT] inspection_collectors`` option
+or the ``ipa-inspection-collectors`` kernel command line argument.
+
+The following environment variables may be set to configure the element:
+
+* ``DIB_IPA_HARDWARE_VERSION`` the version of the ``hardware`` package to
+  install. If unset, the latest version will be installed.
+* ``DIB_IPA_EXTRA_HARDWARE_PACKAGES`` a space-separated list of additional
+  system packages to install.

--- a/elements/ipa-extra-hardware/element-deps
+++ b/elements/ipa-extra-hardware/element-deps
@@ -1,0 +1,1 @@
+package-installs

--- a/elements/ipa-extra-hardware/install.d/61-ipa-extra-hardware
+++ b/elements/ipa-extra-hardware/install.d/61-ipa-extra-hardware
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+IPADIR=/usr/share/ironic-python-agent
+PACKAGE=hardware${DIB_IPA_HARDWARE_VERSION:+==}${DIB_IPA_HARDWARE_VERSION:-}
+
+# Install the python hardware package inside the virtual environment.
+$IPADIR/venv/bin/pip install -c $IPADIR/upper-constraints.txt $PACKAGE
+
+# Because the ironic-python-agent systemd unit does not activate the virtualenv
+# before executing the ironic-python-agent script, the PATH is not updated to
+# point to the bin directory in the virtual environment. We add this symlink so
+# that ironic-python-agent sees the hardware-detect tool in its PATH.
+ln -s $IPADIR/venv/bin/hardware-detect /usr/local/bin/hardware-detect
+
+# Install additional packages as requested.
+if [[ -n ${DIB_IPA_EXTRA_HARDWARE_PACKAGES:-} ]]; then
+    install-packages ${DIB_IPA_EXTRA_HARDWARE_PACKAGES}
+fi

--- a/elements/ipa-extra-hardware/package-installs.yaml
+++ b/elements/ipa-extra-hardware/package-installs.yaml
@@ -1,0 +1,13 @@
+biosdevname:
+ethtool:
+fio:
+hdparm:
+# FIXME: this causes a traceback when enabled with hardware-0.18.
+#infiniband-diags:
+ipmitool:
+lldpad:
+lshw:
+pciutils:
+sdparm:
+smartmontools:
+sysbench:


### PR DESCRIPTION
This element installs the hardware python package to Ironic Python Agent (IPA)
ramdisk. It is designed to be used with the ironic-agent element.