### PR TITLE
Add preliminary stackhpc hardware managers element

### DIFF
--- a/elements/stackhpc-ipa-hardware-managers/README.md
+++ b/elements/stackhpc-ipa-hardware-managers/README.md
@@ -2,7 +2,7 @@ StackHPC Ironic Python Agent (IPA) hardware managers
 ====================================================
 
 This element installs StackHPC hardware managers for use
-during node cleaning.
+during node cleaning, provisioning and inspection.
 
 The following environment variables may be set to configure the element:
 

--- a/elements/stackhpc-ipa-hardware-managers/README.md
+++ b/elements/stackhpc-ipa-hardware-managers/README.md
@@ -1,0 +1,12 @@
+StackHPC Ironic Python Agent (IPA) hardware managers
+====================================================
+
+This element installs StackHPC hardware managers for use
+during node cleaning.
+
+The following environment variables may be set to configure the element:
+
+* ``DIB_IPA_STACKHPC_IPA_HARDWARE_MANAGERS_BRANCH`` is the branch of the
+  ``stackhpc-ipa-hardware managers`` repository to install.
+  Defaults to``master``.
+

--- a/elements/stackhpc-ipa-hardware-managers/element-deps
+++ b/elements/stackhpc-ipa-hardware-managers/element-deps
@@ -1,0 +1,3 @@
+package-installs
+pip-and-virtualenv
+source-repositories

--- a/elements/stackhpc-ipa-hardware-managers/install.d/62-stackhpc-hardware-managers
+++ b/elements/stackhpc-ipa-hardware-managers/install.d/62-stackhpc-hardware-managers
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+IPA_VENV=/usr/share/ironic-python-agent/venv
+
+$IPA_VENV/bin/pip install git+git://github.com/stackhpc/stackhpc-ipa-hardware-managers.git@${DIB_IPA_STACKHPC_IPA_HARDWARE_MANAGERS_BRANCH:-master}

--- a/elements/stackhpc-ipa-hardware-managers/package-installs.yaml
+++ b/elements/stackhpc-ipa-hardware-managers/package-installs.yaml
@@ -1,0 +1,1 @@
+dmidecode:


### PR DESCRIPTION
The purpose of this is to install the hardware manager element
to support running cleaning operations from the IPA ramdisk.

Link to element installed:

https://github.com/stackhpc/stackhpc-ipa-hardware-managers

Once the element is installed it's registered automatically with IPA.