### PR TITLE
Fix NVIDIA CUDA image element

### DIFF
--- a/elements/nvidia-cuda/environment.d/nvidia-cuda
+++ b/elements/nvidia-cuda/environment.d/nvidia-cuda
@@ -8,7 +8,7 @@ case "$DISTRO_NAME" in
 	NVIDIA_CUDA_DISTRO="fedora25"
 	;;
     ubuntu* | debian*)
-	NVIDIA_CUDA_DISTRO="ubuntu1604"
+	NVIDIA_CUDA_DISTRO="ubuntu1804"
 	;;
     *)
 	echo "Distro \"$DISTRO_NAME\" is not recognised"

--- a/elements/nvidia-cuda/environment.d/nvidia-cuda
+++ b/elements/nvidia-cuda/environment.d/nvidia-cuda
@@ -19,6 +19,6 @@ esac
 export NVIDIA_CUDA_DISTRO
 export NVIDIA_CUDA_REPO=${DIB_NVIDIA_CUDA_REPO:-"https://developer.download.nvidia.com/compute/cuda/repos/${NVIDIA_CUDA_DISTRO}/x86_64"}
 export NVIDIA_CUDA_PUBKEY=${DIB_NVIDIA_CUDA_PUBKEY:-"http://developer.download.nvidia.com/compute/cuda/repos/${NVIDIA_CUDA_DISTRO}/x86_64/7fa2af80.pub"}
-export NVIDIA_CUDA_VERSION=${DIB_NVIDIA_CUDA_VERSION:-"9.0.176-1"}
+export NVIDIA_CUDA_VERSION=${DIB_NVIDIA_CUDA_VERSION:-"10.1.168-1"}
 export NVIDIA_CUDA_PKGLIST=${DIB_NVIDIA_CUDA_PKGLIST:-"cuda"}
 export NVIDIA_CUDA_DELETE_REPO=${DIB_NVIDIA_CUDA_DELETE_REPO:-y}

--- a/elements/nvidia-cuda/environment.d/nvidia-cuda
+++ b/elements/nvidia-cuda/environment.d/nvidia-cuda
@@ -18,6 +18,7 @@ esac
 
 export NVIDIA_CUDA_DISTRO
 export NVIDIA_CUDA_REPO=${DIB_NVIDIA_CUDA_REPO:-"https://developer.download.nvidia.com/compute/cuda/repos/${NVIDIA_CUDA_DISTRO}/x86_64"}
+export NVIDIA_CUDA_PUBKEY=${DIB_NVIDIA_CUDA_PUBKEY:-"http://developer.download.nvidia.com/compute/cuda/repos/${NVIDIA_CUDA_DISTRO}/x86_64/7fa2af80.pub"}
 export NVIDIA_CUDA_VERSION=${DIB_NVIDIA_CUDA_VERSION:-"9.0.176-1"}
 export NVIDIA_CUDA_PKGLIST=${DIB_NVIDIA_CUDA_PKGLIST:-"cuda"}
 export NVIDIA_CUDA_DELETE_REPO=${DIB_NVIDIA_CUDA_DELETE_REPO:-y}

--- a/elements/nvidia-cuda/install.d/95-nvidia-cuda
+++ b/elements/nvidia-cuda/install.d/95-nvidia-cuda
@@ -2,15 +2,18 @@
 
 case "$DISTRO_NAME" in
     centos* | rhel*)
-	yum install -y kernel-devel-$(uname -r) kernel-headers-$(uname -r)
+	KERNEL_VERSION=$(ls /boot/vmlinuz*x86_64 | sort -n | tail -n1 | cut -d'-' -f2-)
+	yum install -y kernel-devel-$KERNEL_VERSION kernel-headers-$KERNEL_VERSION
 	yum install -y $NVIDIA_CUDA_PKGLIST
 	;;
     fedora*)
-	dnf install -y kernel-devel-$(uname -r) kernel-headers-$(uname -r)
+	KERNEL_VERSION=$(ls /boot/vmlinuz*x86_64 | sort -n | tail -n1 | cut -d'-' -f2-)
+	dnf install -y kernel-devel-$KERNEL_VERSION kernel-headers-$KERNEL_VERSION
 	dnf install -y $NVIDIA_CUDA_PKGLIST
 	;;
     ubuntu* | debian*)
-	apt-get -y install linux-headers-$(uname -r)
+	KERNEL_VERSION="$(ls /boot/vmlinuz*generic | sort -n | tail -n1 | cut -d'-' -f2-)"
+	apt-get -y install linux-headers-$KERNEL_VERSION
 	apt-get -y install $NVIDIA_CUDA_PKGLIST
 	;;
     *)

--- a/elements/nvidia-cuda/install.d/95-nvidia-cuda
+++ b/elements/nvidia-cuda/install.d/95-nvidia-cuda
@@ -2,12 +2,15 @@
 
 case "$DISTRO_NAME" in
     centos* | rhel*)
+	yum install -y kernel-devel-$(uname -r) kernel-headers-$(uname -r)
 	yum install -y $NVIDIA_CUDA_PKGLIST
 	;;
     fedora*)
+	dnf install -y kernel-devel-$(uname -r) kernel-headers-$(uname -r)
 	dnf install -y $NVIDIA_CUDA_PKGLIST
 	;;
     ubuntu* | debian*)
+	apt-get -y install linux-headers-$(uname -r)
 	apt-get -y install $NVIDIA_CUDA_PKGLIST
 	;;
     *)

--- a/elements/nvidia-cuda/pre-install.d/01-nvidia-cuda-repo
+++ b/elements/nvidia-cuda/pre-install.d/01-nvidia-cuda-repo
@@ -8,9 +8,9 @@ case "$DISTRO_NAME" in
 	dnf install -y ${NVIDIA_CUDA_REPO}/cuda-repo-${NVIDIA_CUDA_DISTRO}-${NVIDIA_CUDA_VERSION}.x86_64.rpm
 	;;
     ubuntu* | debian*)
-	apt-key adv --fetch-keys ${NVIDIA_CUDA_PUBKEY}
 	wget ${NVIDIA_CUDA_REPO}/cuda-repo-${NVIDIA_CUDA_DISTRO}_${NVIDIA_CUDA_VERSION}_amd64.deb
 	dpkg -i cuda-repo-${NVIDIA_CUDA_DISTRO}_${NVIDIA_CUDA_VERSION}_amd64.deb
+	apt-key adv --fetch-keys ${NVIDIA_CUDA_PUBKEY}
 	apt-get update
 	;;
     *)

--- a/elements/nvidia-cuda/pre-install.d/01-nvidia-cuda-repo
+++ b/elements/nvidia-cuda/pre-install.d/01-nvidia-cuda-repo
@@ -8,6 +8,7 @@ case "$DISTRO_NAME" in
 	dnf install -y ${NVIDIA_CUDA_REPO}/cuda-repo-${NVIDIA_CUDA_DISTRO}-${NVIDIA_CUDA_VERSION}.x86_64.rpm
 	;;
     ubuntu* | debian*)
+	apt-key adv --fetch-keys ${NVIDIA_CUDA_PUBKEY}
 	wget ${NVIDIA_CUDA_REPO}/cuda-repo-${NVIDIA_CUDA_DISTRO}_${NVIDIA_CUDA_VERSION}_amd64.deb
 	dpkg -i cuda-repo-${NVIDIA_CUDA_DISTRO}_${NVIDIA_CUDA_VERSION}_amd64.deb
 	apt-get update


### PR DESCRIPTION
Fixes the following issues:
- Uses ubuntu1804 base image
- Installs kernel header required by the new cuda drivers
- Adds repository key for ubuntu cuda repo