### PR TITLE
Prevent Cloud-init erasing LINKDELAY

### DIFF
--- a/elements/centos-linkup-extra/install.d/98-centos-linkup-extra
+++ b/elements/centos-linkup-extra/install.d/98-centos-linkup-extra
@@ -8,3 +8,5 @@ set -o pipefail
 
 # Add a LINKDELAY value to /etc/sysconfig/network
 echo -e "# Allow extra time for link up\nLINKDELAY=${CENTOS_LINKUP_EXTRA_SECS}" >> /etc/sysconfig/network
+# Prevent Cloudinit writing over LINKDELAY setting
+echo -e "network: {config: disabled}" >> /etc/cloud/cloud.cfg.d/99-disable-custom-net-conf.cfg


### PR DESCRIPTION
Cloud-init uses default generated network config to try and configure
a link for DHCP. This overwrites the LINKDELAY setting, which is required
in some cases to bring up the link.

This prevents the configuration of a udev rule by cloud init and the addition of the MAC address to the ifcfg script for the active interface. DNS still appears to be configured, but is missing the 'configured by Cloud init header'. None of these issues appear to prevent the image booting, running cloud-init and enabling the user to log in on a test node connected to a single network.