### PR TITLE
Fix adding ipa-extra-hardware

### DIFF
--- a/elements/ipa-extra-hardware/README.rst
+++ b/elements/ipa-extra-hardware/README.rst
@@ -21,3 +21,6 @@ The following environment variables may be set to configure the element:
   version will be installed.
 * ``DIB_IPA_EXTRA_HARDWARE_PACKAGES`` a space-separated list of additional
   system packages to install.
+
+For Wallaby and later releases, it is recommended to use an upstream version
+of the `element <https://opendev.org/openstack/ironic-python-agent-builder/src/branch/master/dib/extra-hardware>`_.

--- a/elements/ipa-extra-hardware/install.d/61-ipa-extra-hardware
+++ b/elements/ipa-extra-hardware/install.d/61-ipa-extra-hardware
@@ -6,17 +6,29 @@ fi
 set -eu
 set -o pipefail
 
-IPADIR=/usr/share/ironic-python-agent
 PACKAGE=${DIB_IPA_HARDWARE_PACKAGE:-hardware${DIB_IPA_HARDWARE_VERSION:+==}${DIB_IPA_HARDWARE_VERSION:-}}
 
-# Install the python hardware package inside the virtual environment.
-$IPADIR/venv/bin/pip install -c $IPADIR/upper-constraints.txt $PACKAGE
+if [[ -d /usr/share/ironic-python-agent ]]; then
+    IPADIR=/usr/share/ironic-python-agent
+else
+    IPADIR=/opt/ironic-python-agent
+fi
+
+if [[ -d "$IPADIR/venv" ]]; then
+    $IPADIR/venv/bin/pip install -c $IPADIR/upper-constraints.txt $PACKAGE
+else
+    $IPADIR/bin/pip install -c /tmp/requirements/upper-constraints.txt $PACKAGE
+fi
 
 # Because the ironic-python-agent systemd unit does not activate the virtualenv
 # before executing the ironic-python-agent script, the PATH is not updated to
 # point to the bin directory in the virtual environment. We add this symlink so
 # that ironic-python-agent sees the hardware-detect tool in its PATH.
-ln -s $IPADIR/venv/bin/hardware-detect /usr/local/bin/hardware-detect
+if [[ -d "$IPADIR/venv" ]]; then
+    ln -s $IPADIR/venv/bin/hardware-detect /usr/local/bin/hardware-detect
+else
+    ln -s $IPADIR/bin/hardware-detect /usr/local/bin/hardware-detect
+fi
 
 # Install additional packages as requested.
 if [[ -n ${DIB_IPA_EXTRA_HARDWARE_PACKAGES:-} ]]; then


### PR DESCRIPTION
Depending on OpenStack release, the location of IPA and pip installations is different. This change aims to detect the location and use it automatically. Without it, adding `ipa-extra-hardware` element in Ussuri and newer releases fails.

Some people were already correcting this in the past, hence they are mentioned as co-authors.