### PR TITLE
Adds a unmask-tmp element

### DIFF
--- a/elements/unmask-tmp/README.rst
+++ b/elements/unmask-tmp/README.rst
@@ -1,0 +1,7 @@
+==========
+unmask-tmp
+==========
+
+Workaround for the issue described `here <https://bugzilla.redhat.com/show_bug.cgi?id=1243494>`_.
+The symptom to lookout for is that the rootfs is mounted read-only. This has also been observed
+on CentOS 8.

--- a/elements/unmask-tmp/cleanup.d/99-unmask-tmp
+++ b/elements/unmask-tmp/cleanup.d/99-unmask-tmp
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "${DIB_DEBUG_TRACE:-1}" -gt 0 ]; then
+    set -x
+fi
+set -u
+set -o pipefail
+
+sudo rm -f $TARGET_ROOT/etc/systemd/system/tmp.mount && echo "Successfully removed etc/systemd/system/tmp.mount" || true


### PR DESCRIPTION
This allows you to use a separate /tmp partition.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1243494