### PR TITLE
Rocky9.2 ofed install opts

### DIFF
--- a/elements/rocky9-ofed/containerfiles/rocky-9-ofed
+++ b/elements/rocky9-ofed/containerfiles/rocky-9-ofed
@@ -38,12 +38,12 @@ RUN systemctl unmask console-getty.service dev-hugepages.mount \
 # Apply OFED installation
 # FIXME: the hardcoded kernel version should be dynamically deduced
 RUN dnf config-manager --set-enabled appstream crb && dnf install -y perl cmake kernel-devel \
-  python3-devel perl-generators python3 rpm-build elfutils-libelf-devel zlib-devel \
+  kernel-headers python3-devel perl-generators python3 rpm-build elfutils-libelf-devel zlib-devel \
   gcc-c++ gdb-headless glib2-devel patch lsof libmnl openssl-devel pciutils-devel \
   pkgconf-pkg-config libstdc++-devel libnl3-devel libtool numactl-devel \
   systemd-devel kernel-rpm-macros glibc-devel pciutils gcc valgrind-devel iptables-devel \
   bison libdb-devel elfutils-devel tcsh binutils-devel flex gcc-gfortran  \
-  python3-Cython python3-docutils libmnl-devel
+  python3-Cython python3-docutils libmnl-devel libusbx-devel fuse-devel
 
 RUN curl -L https://content.mellanox.com/ofed/MLNX_OFED-DIB_MLNX_OFED_VERSION/MLNX_OFED_SRC-DIB_MLNX_OFED_VERSION.tgz --output /tmp/MLNX_OFED_SRC-DIB_MLNX_OFED_VERSION.tgz \
   && cd /tmp \

--- a/elements/rocky9-ofed/containerfiles/rocky-9-ofed
+++ b/elements/rocky9-ofed/containerfiles/rocky-9-ofed
@@ -48,5 +48,5 @@ RUN dnf config-manager --set-enabled appstream crb && dnf install -y perl cmake 
 RUN curl -L https://content.mellanox.com/ofed/MLNX_OFED-DIB_MLNX_OFED_VERSION/MLNX_OFED_SRC-DIB_MLNX_OFED_VERSION.tgz --output /tmp/MLNX_OFED_SRC-DIB_MLNX_OFED_VERSION.tgz \
   && cd /tmp \
   && tar -xzf MLNX_OFED_SRC-DIB_MLNX_OFED_VERSION.tgz \
-  && /tmp/MLNX_OFED_SRC-DIB_MLNX_OFED_VERSION/install.pl --basic --kernel $(cd /lib/modules && ls -t1 | head -n 1) \
+  && /tmp/MLNX_OFED_SRC-DIB_MLNX_OFED_VERSION/install.pl --kernel $(cd /lib/modules && ls -t1 | head -n 1) DIB_MLNX_OFED_INSTALL_ARGS \
   && rm -rf /tmp/MLNX_OFED_SRC-DIB_MLNX_OFED_VERSION*

--- a/elements/rocky9-ofed/environment.d/01-containerfile.bash
+++ b/elements/rocky9-ofed/environment.d/01-containerfile.bash
@@ -5,5 +5,5 @@ then
     path="$( dirname $path)"
     export DIB_CONTAINERFILE_DOCKERFILE="$path/containerfiles/rocky-9-ofed"
     sed -i 's/DIB_MLNX_OFED_VERSION/'"$DIB_MLNX_OFED_VERSION"'/g' $DIB_CONTAINERFILE_DOCKERFILE || true
+    sed -i 's/DIB_MLNX_OFED_INSTALL_ARGS/'"${DIB_MLNX_OFED_INSTALL_ARGS:---hypervisor}"'/g' $DIB_CONTAINERFILE_DOCKERFILE || true
 fi
-


### PR DESCRIPTION
The `--basic` install is rumoured to not provide all of the things. Make the install type (and other args to `install.pl`) configurable, and default to the `--hypervisor` install.