### PR TITLE
Add rocky-container-stackhpc element

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,3 +30,4 @@ This repository provides the following DIB elements:
 * ``centos-linkup-extra``: Allows extra time for slow network links to come up.
 * ``centos7-vault``: Deploy older releases of CentOS 7
 * ``cloud-init-growpart-lvm``: Grows designated LVM partition.
+* ``rocky-container-stackhpc``: Custom containerfiles for usage with rocky-container element builds

--- a/elements/rocky-container-stackhpc/README.rst
+++ b/elements/rocky-container-stackhpc/README.rst
@@ -1,0 +1,8 @@
+========================
+rocky-container-stackhpc
+========================
+Custom containerfiles for usage with ``rocky-container`` builds.
+Usage:
+Set ``DIB_CONTAINERFILE_DOCKERFILE`` environment variable to custom
+Containerfile path provided by this role, e.g.:
+DIB_CONTAINERFILE_DOCKERFILE: "/opt/kayobe/src/stackhpc-image-elements/elements/rocky-container-stackhpc/containerfiles/9-stackhpc"

--- a/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
+++ b/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
@@ -1,0 +1,18 @@
+# Based on https://github.com/openstack/diskimage-builder/blob/master/diskimage_builder/elements/rocky-container/containerfiles/9
+
+FROM docker.io/rockylinux/rockylinux:9
+
+RUN dnf group install -y 'Minimal Install' --allowerasing && \
+    dnf install -y findutils util-linux \
+    https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/cloud-init-23.1.1-12.el9.noarch.rpm
+
+RUN sed -i "s/renderers:.*/renderers: ['network-manager']\n      activators: ['network-manager']/" /etc/cloud/cloud.cfg
+
+RUN systemctl unmask console-getty.service dev-hugepages.mount \
+    getty.target sys-fs-fuse-connections.mount systemd-logind.service \
+    systemd-remount-fs.service
+
+# /etc/machine-id needs to be populated for /bin/kernel-install to
+# correctly copy kernels into /boot.  We will clear this out in the
+# final image.
+RUN systemd-machine-id-setup

--- a/elements/rocky-container-stackhpc/element-deps
+++ b/elements/rocky-container-stackhpc/element-deps
@@ -1,0 +1,1 @@
+rocky-container


### PR DESCRIPTION
Uses cloud-init with NM support from c9s and explicitly sets network renderer and activator to network-manager.