### PR TITLE
Bump cloud-init in rocky-container-stackhpc

### DIFF
--- a/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
+++ b/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
@@ -4,7 +4,7 @@ FROM docker.io/rockylinux/rockylinux:9
 
 RUN dnf group install -y 'Minimal Install' --allowerasing && \
     dnf install -y findutils util-linux \
-    https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/cloud-init-23.1.1-12.el9.noarch.rpm
+    https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/cloud-init-23.4-7.el9.noarch.rpm
 
 RUN sed -i "s/renderers:.*/renderers: ['network-manager']\n      activators: ['network-manager']/" /etc/cloud/cloud.cfg
 


### PR DESCRIPTION
The old version is no longer available. We should probably find a long term solution to this at some point