### PR TITLE
Fix Rocky container sed formatting

### DIFF
--- a/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
+++ b/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
@@ -6,7 +6,7 @@ RUN dnf group install -y 'Minimal Install' --allowerasing && \
     dnf install -y findutils util-linux \
     https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/cloud-init-23.4-7.el9.noarch.rpm
 
-RUN sed -i "s/renderers:.*/renderers: ['network-manager']\n      activators: ['network-manager']/" /etc/cloud/cloud.cfg
+RUN sed -i "s/renderers:.*/{renderers: ['network-manager'], activators: ['network-manager'] }/" /etc/cloud/cloud.cfg
 
 RUN systemctl unmask console-getty.service dev-hugepages.mount \
     getty.target sys-fs-fuse-connections.mount systemd-logind.service \


### PR DESCRIPTION
Whitespace in the cloud.cfg file could previously cause the sed to fail, preventing the image from booting properly:
```
[   12.623671] cloud-init[966]: 2024-03-27 09:48:06,919 - util.py[WARNING]: Failed loading yaml blob. Invalid format at line 102 column 5: "while parsing a block mapping
[   12.626039] cloud-init[966]:   in "<unicode string>", line 102, column 5:
[   12.627229] cloud-init[966]:         renderers: ['network-manager']
[   12.628358] cloud-init[966]:         ^
[   12.629054] cloud-init[966]: expected <block end>, but found '<block mapping start>'
[   12.630460] cloud-init[966]:   in "<unicode string>", line 103, column 7:
[   12.631628] cloud-init[966]:           activators: ['network-manager']
```