### PR TITLE
Unpin cloud-init in StackHPC RL9 image

### DIFF
--- a/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
+++ b/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
@@ -3,8 +3,7 @@
 FROM docker.io/rockylinux/rockylinux:9
 
 RUN dnf group install -y 'Minimal Install' --allowerasing && \
-    dnf install -y findutils util-linux \
-    https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/Packages/cloud-init-23.4-7.el9.noarch.rpm
+    dnf install -y findutils util-linux cloud-init
 
 RUN sed -i "s/renderers:.*/renderers: ['network-manager']\n      activators: ['network-manager']/" /etc/cloud/cloud.cfg
 


### PR DESCRIPTION
The cloud-init pin has become out of date. The pin doesn't seem to serve any meaningful purpose and frequently becomes outdated. The other packages in the file are unpinned.

This change removes the pin to avoid future issues