### PR TITLE
rocky: Adapt sed for setting activators and renderers

### DIFF
--- a/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
+++ b/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
@@ -5,7 +5,7 @@ FROM docker.io/rockylinux/rockylinux:9
 RUN dnf group install -y 'Minimal Install' --allowerasing && \
     dnf install -y findutils util-linux cloud-init
 
-RUN sed -i "s/renderers:.*/renderers: ['network-manager']\n      activators: ['network-manager']/" /etc/cloud/cloud.cfg
+RUN sed -i "s/renderers:.*/renderers: ['network-manager']\n    activators: ['network-manager']/" /etc/cloud/cloud.cfg
 
 RUN systemctl unmask console-getty.service dev-hugepages.mount \
     getty.target sys-fs-fuse-connections.mount systemd-logind.service \


### PR DESCRIPTION
After #63 (switching to Rocky version of cloud-init package) the bundled config has changed and we end up with:
```
  network:
    renderers: ['network-manager']
      activators: ['network-manager']
```