### PR TITLE
Build DIB images from StackHPC package mirrors

### DIFF
--- a/elements/apt-no-verify-peer/README.rst
+++ b/elements/apt-no-verify-peer/README.rst
@@ -1,0 +1,6 @@
+========================
+apt-no-verify-peer
+========================
+Disable certificate verifiction for apt repositories.
+
+No additional configuration is needed, other than including the element.

--- a/elements/apt-no-verify-peer/cleanup.d/99-unset-apt-verify-peer-false
+++ b/elements/apt-no-verify-peer/cleanup.d/99-unset-apt-verify-peer-false
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-1} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+sudo rm -f ${TARGET_ROOT}/etc/apt/apt.conf.d/90no-verify-peer # dib-lint: safe_sudo

--- a/elements/apt-no-verify-peer/root.d/70-set-apt-verify-peer-false
+++ b/elements/apt-no-verify-peer/root.d/70-set-apt-verify-peer-false
@@ -1,0 +1,11 @@
+#!/bin/bash
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+# Ensure apt doesn't verify the certificate issuer
+sudo mkdir -p ${TARGET_ROOT}/etc/apt/apt.conf.d/ # dib-lint: safe_sudo
+echo 'Acquire::https::Verify-Peer "false";' |\
+  sudo tee ${TARGET_ROOT}/etc/apt/apt.conf.d/90no-verify-peer > /dev/null # dib-lint: safe_sudo

--- a/elements/purge-command-not-found/README.rst
+++ b/elements/purge-command-not-found/README.rst
@@ -1,0 +1,12 @@
+========================
+purge-command-not-found
+========================
+Purge command-not-found packages from an image.
+
+Currently the pulp_deb plugin in Pulp does not support certain types of
+content, including i18n files and command-not-found indices. This breaks APT
+when the command-not-found is installed. This element can be used to
+uninstall the package, prior to running any other APT commands that may target
+Pulp package mirrors.
+
+No additional configuration is needed, other than including the element.

--- a/elements/purge-command-not-found/pre-install.d/02-purge-command-not-found
+++ b/elements/purge-command-not-found/pre-install.d/02-purge-command-not-found
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+sudo apt purge -y command-not-found python3-commandnotfound

--- a/elements/rocky-container-stackhpc/README.rst
+++ b/elements/rocky-container-stackhpc/README.rst
@@ -2,7 +2,26 @@
 rocky-container-stackhpc
 ========================
 Custom containerfiles for usage with ``rocky-container`` builds.
+
 Usage:
 Set ``DIB_CONTAINERFILE_DOCKERFILE`` environment variable to custom
 Containerfile path provided by this role, e.g.:
 DIB_CONTAINERFILE_DOCKERFILE: "/opt/kayobe/src/stackhpc-image-elements/elements/rocky-container-stackhpc/containerfiles/9-stackhpc"
+
+Pass ``ROCKY_USE_CUSTOM_DNF_MIRRORS=true`` as a build-arg to disable
+upstream Rocky repository mirrors.
+
+``ROCKY_CUSTOM_DNF_MIRROR_URLS`` is a comma-delimited list of repository URLs
+to build an image from, and should also be passed as a build-arg.
+``ROCKY_CUSTOM_DNF_MIRROR_URLS`` will be removed from the final image.
+
+Use ``DIB_CONTAINERFILE_BUILDOPTS`` to pass through build args to the container
+engine:
+
+.. code-block:: yaml
+    DIB_CONTAINERFILE_BUILDOPTS: >-
+    --build-arg=ROCKY_USE_CUSTOM_DNF_MIRRORS=true
+    --build-arg=ROCKY_CUSTOM_DNF_MIRROR_URLS=http://localhost/rocky/9/AppStream/x86_64/os/,http://localhost/rocky/9/BaseOS/x86_64/os/
+
+Set ``DIB_ROCKY_CONTAINER_STACKHPC_RESTORE_UPSTREAM_REPOFILES=true`` to restore the
+upstream Rocky repository mirror configuration in the final image. 

--- a/elements/rocky-container-stackhpc/cleanup.d/80-cleanup-and-restore-repofiles
+++ b/elements/rocky-container-stackhpc/cleanup.d/80-cleanup-and-restore-repofiles
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+DIB_ROCKY_CONTAINER_STACKHPC_RESTORE_UPSTREAM_REPOFILES=${DIB_ROCKY_CONTAINER_STACKHPC_RESTORE_UPSTREAM_REPOFILES:-"false"}
+
+[ -n "$TARGET_ROOT" ]
+
+# Remove custom repo files
+if [ -d /tmp/orig_repos ]; then 
+  sudo rm -f ${TARGET_ROOT}/etc/yum.repos.d/*.repo
+fi
+
+# Conditionally restore upstream repo files
+if [[ ${DIB_ROCKY_CONTAINER_STACKHPC_RESTORE_UPSTREAM_REPOFILES} != "false" ]]; then
+  sudo cp -f ${TARGET_ROOT}/tmp/orig_repos/*.repo ${TARGET_ROOT}/etc/yum.repos.d/
+fi
+
+# Cleanup temporary copies of original repo files
+sudo rm -rf ${TARGET_ROOT}/tmp/orig_repos

--- a/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
+++ b/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
@@ -1,6 +1,18 @@
 # Based on https://github.com/openstack/diskimage-builder/blob/master/diskimage_builder/elements/rocky-container/containerfiles/9
 
 FROM docker.io/rockylinux/rockylinux:9
+ARG ROCKY_USE_CUSTOM_DNF_MIRRORS="false"
+# Comma-delimited list of repo URLs
+ARG ROCKY_CUSTOM_DNF_MIRROR_URLS
+
+RUN if [[ ${ROCKY_USE_CUSTOM_DNF_MIRRORS} != "false" ]]; then \
+      dnf -y install 'dnf-command(config-manager)' && \
+      mkdir /tmp/orig_repos && mv /etc/yum.repos.d/*.repo /tmp/orig_repos/ && \
+      for REPO_URL in $(echo ${ROCKY_CUSTOM_DNF_MIRROR_URLS} | sed 's/,/ /g'); do \
+        dnf config-manager --add-repo ${REPO_URL}; \
+      done && \
+      dnf --allowerasing -y distro-sync; \
+    fi
 
 RUN dnf group install -y 'Minimal Install' --allowerasing && \
     dnf install -y findutils util-linux cloud-init

--- a/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
+++ b/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
@@ -5,7 +5,14 @@ FROM docker.io/rockylinux/rockylinux:9
 RUN dnf group install -y 'Minimal Install' --allowerasing && \
     dnf install -y findutils util-linux cloud-init
 
-RUN sed -i "s/renderers:.*/renderers: ['network-manager']\n    activators: ['network-manager']/" /etc/cloud/cloud.cfg
+COPY <<EOF /etc/cloud/cloud.cfg.d/10-NetworkManager.cfg
+---
+system_info:
+  activators:
+    - "network-manager"
+
+merge_type: 'dict(recurse_array)'
+EOF
 
 RUN systemctl unmask console-getty.service dev-hugepages.mount \
     getty.target sys-fs-fuse-connections.mount systemd-logind.service \


### PR DESCRIPTION
Build on https://github.com/stackhpc/stackhpc-image-elements/pull/59 to make building DIB images from Ark package mirrors possible.

- Make network-manager cloud-init config less sensitive to whitespace.
- Allow a list of repo mirror URLs to be passed into the rocky-container image, alongside cleanup config.
- Add an element to disable apt mirror TLS verification, this is useful when a HTTP authenticating proxy is used in front of apt mirrors with basic auth.