### PR TITLE
Look for temporary directory containing upstream repo files in TARGET_ROOT

### DIFF
--- a/elements/rocky-container-stackhpc/cleanup.d/80-cleanup-and-restore-repofiles
+++ b/elements/rocky-container-stackhpc/cleanup.d/80-cleanup-and-restore-repofiles
@@ -11,7 +11,7 @@ DIB_ROCKY_CONTAINER_STACKHPC_RESTORE_UPSTREAM_REPOFILES=${DIB_ROCKY_CONTAINER_ST
 [ -n "$TARGET_ROOT" ]
 
 # Remove custom repo files
-if [ -d /tmp/orig_repos ]; then 
+if [ -d "${TARGET_ROOT}/tmp/orig_repos" ]; then 
   sudo rm -f ${TARGET_ROOT}/etc/yum.repos.d/*.repo
 fi
 


### PR DESCRIPTION
Cleanup scripts are executed outside of the chroot, so they need the absolute path to reference any directories inside the build chroot.

I missed this one when adding the initial feature.