### PR TITLE
Add ixgbe element

### DIFF
--- a/elements/ixgbe/README.rst
+++ b/elements/ixgbe/README.rst
@@ -1,0 +1,6 @@
+=====
+ixgbe
+=====
+Install custom ixgbe driver.
+
+DIB_IXGBE_KERNEL_BUILD should be set the to target kernel in your image.

--- a/elements/ixgbe/environment.d/ixgbe
+++ b/elements/ixgbe/environment.d/ixgbe
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+export DIB_IXGBE_KERNEL_BUILD=${DIB_IXGBE_KERNEL_BUILD:-"5.14.0-592.el9.x86_64"}

--- a/elements/ixgbe/install.d/10-ixgbe
+++ b/elements/ixgbe/install.d/10-ixgbe
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+wget https://github.com/intel/ethernet-linux-ixgbe/releases/download/v6.1.5/ixgbe-6.1.5.tar.gz
+
+export ARCH=x86
+
+export BUILD_KERNEL=$DIB_IXGBE_BUILD_KERNEL
+
+rpmbuild -tb ixgbe-6.1.5.tar.gz
+
+dnf localinstall -y /root/rpmbuild/RPMS/x86_64/ixgbe-6.1.5-1.x86_64.rpm

--- a/elements/ixgbe/package-installs.yaml
+++ b/elements/ixgbe/package-installs.yaml
@@ -1,0 +1,7 @@
+wget:
+rpm-build:
+elfutils-libelf-devel:
+kernel-abi-stablelists:
+kernel-devel:
+kernel-rpm-macros:
+kernel-headers:


### PR DESCRIPTION
Supports installing the current latest ixgbe driver onto RHEL-based images. The build kernel is configurable as DIB runs under chroot, so it would otherwise pick up the host OS instead of the image OS.