### PR TITLE
Ensure rocky base image with correct minor version 

### DIFF
--- a/elements/rocky-container-stackhpc/README.rst
+++ b/elements/rocky-container-stackhpc/README.rst
@@ -15,6 +15,11 @@ upstream Rocky repository mirrors.
 to build an image from, and should also be passed as a build-arg.
 ``ROCKY_CUSTOM_DNF_MIRROR_URLS`` will be removed from the final image.
 
+Pass ``ROCKY_VERSION`` as a build-arg to specify a rockylinux/rockylinux tag.
+Otherwise the floating tag for version 9 will be used. This can surprise you
+when a new Rocky Linux minor release is out and the tag is updated, so you should
+include the minor version in the tag (eg ``ROCKY_VERSION=9.7``).
+
 Use ``DIB_CONTAINERFILE_BUILDOPTS`` to pass through build args to the container
 engine:
 
@@ -22,6 +27,7 @@ engine:
     DIB_CONTAINERFILE_BUILDOPTS: >-
     --build-arg=ROCKY_USE_CUSTOM_DNF_MIRRORS=true
     --build-arg=ROCKY_CUSTOM_DNF_MIRROR_URLS=http://localhost/rocky/9/AppStream/x86_64/os/,http://localhost/rocky/9/BaseOS/x86_64/os/
+    --build-arg=ROCKY_VERSION=9.7
 
 Set ``DIB_ROCKY_CONTAINER_STACKHPC_RESTORE_UPSTREAM_REPOFILES=true`` to restore the
-upstream Rocky repository mirror configuration in the final image. 
+upstream Rocky repository mirror configuration in the final image.

--- a/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
+++ b/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
@@ -1,6 +1,7 @@
 # Based on https://github.com/openstack/diskimage-builder/blob/master/diskimage_builder/elements/rocky-container/containerfiles/9
-
-FROM docker.io/rockylinux/rockylinux:9
+# For least surprise when a new minor version is out, specify the full version, eg `ROCKY_VERSION=9.7`
+ARG ROCKY_VERSION=9
+FROM docker.io/rockylinux/rockylinux:${ROCKY_VERSION}
 ARG ROCKY_USE_CUSTOM_DNF_MIRRORS="false"
 # Comma-delimited list of repo URLs
 ARG ROCKY_CUSTOM_DNF_MIRROR_URLS

--- a/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
+++ b/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
@@ -1,7 +1,7 @@
 # Based on https://github.com/openstack/diskimage-builder/blob/master/diskimage_builder/elements/rocky-container/containerfiles/9
 # For least surprise when a new minor version is out, specify the full version, eg `ROCKY_VERSION=9.7`
 ARG ROCKY_VERSION=9
-FROM docker.io/rockylinux/rockylinux:${ROCKY_VERSION}
+FROM quay.io/rockylinux/rockylinux:${ROCKY_VERSION}
 ARG ROCKY_USE_CUSTOM_DNF_MIRRORS="false"
 # Comma-delimited list of repo URLs
 ARG ROCKY_CUSTOM_DNF_MIRROR_URLS


### PR DESCRIPTION
Previously, we used rockylinux:9 without specifying the minor version.

Also move to quay.io