### PR TITLE
fix: disable repositories second time to downgrade kernel

### DIFF
--- a/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
+++ b/elements/rocky-container-stackhpc/containerfiles/9-stackhpc
@@ -18,6 +18,15 @@ RUN if [[ ${ROCKY_USE_CUSTOM_DNF_MIRRORS} != "false" ]]; then \
 RUN dnf group install -y 'Minimal Install' --allowerasing && \
     dnf install -y findutils util-linux cloud-init
 
+# Repositories need to be disabled a second time to downgrade kernel.
+RUN if [[ ${ROCKY_USE_CUSTOM_DNF_MIRRORS} != "false" ]]; then \
+      dnf config-manager --disable \* && \
+      for REPO_URL in $(echo ${ROCKY_CUSTOM_DNF_MIRROR_URLS} | sed 's/,/ /g'); do \
+        dnf config-manager --add-repo ${REPO_URL}; \
+      done && \
+      dnf --allowerasing -y distro-sync; \
+    fi
+
 COPY <<EOF /etc/cloud/cloud.cfg.d/10-NetworkManager.cfg
 ---
 system_info:


### PR DESCRIPTION
It has been observed the image built with custom repositories will contain the latest kernel and will not downgrade to match what is contained within the custom repositories. By disabling the repositories after installing `Minimal Install` it should then trigger a downgrade.