### PR TITLE
feat: require `cloud-init` waits for `systemd-udev-settle`

### DIFF
--- a/elements/cloud-init-mlx5/install.d/95-cloud-init-local
+++ b/elements/cloud-init-mlx5/install.d/95-cloud-init-local
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Exit immediately if a command exits with a non-zero status (-e),
+# treat unset variables as an error and exit immediately (-u),
+# and ensure that a pipeline fails if any part fails (-o pipefail).
+set -euo pipefail
+
+# Display a message indicating the purpose of the script
+echo "Creating systemd override for cloud-init-local.service to ensure it starts systemd-udev-settle.service"
+
+# Define the path to the systemd override directory
+OVERRIDE_DIR="/etc/systemd/system/cloud-init-local.service.d"
+
+# Create the override directory if it doesn't already exist
+mkdir -p "${OVERRIDE_DIR}"
+
+# Define the path to the override file
+OVERRIDE_FILE="${OVERRIDE_DIR}/udev-settle-override.conf"
+
+# Write the override configuration
+cat <<EOF >"${OVERRIDE_FILE}"
+[Unit]
+Wants=systemd-udev-settle.service
+After=systemd-udev-settle.service
+EOF
+
+# Ensure correct permissions
+chmod 755 "${OVERRIDE_DIR}"
+chmod 644 "${OVERRIDE_FILE}"
+
+# Display a message indicating that the override has been created
+echo "Systemd override for cloud-init-local.service created successfully"

--- a/elements/cloud-init-mlx5/install.d/README.rst
+++ b/elements/cloud-init-mlx5/install.d/README.rst
@@ -1,0 +1,5 @@
+===============
+cloud-init-mlx5
+===============
+
+Configures cloud-init-local.service with configuration to ensure cloud-init only starts after systemd-udev-settle.service


### PR DESCRIPTION
It has been observed on `Rocky Linux 10` that hosts where `cloud-init` is configuring `mlx5` cards will fail as the interface is not ready in time for `cloud-init`. We can opt to wait on `systemd-udev-settle` as a solution to this race condition.

https://bugzilla.redhat.com/show_bug.cgi?id=2182173